### PR TITLE
Start the logger before calling _load_data_model().

### DIFF
--- a/fuzzfmk/plumbing.py
+++ b/fuzzfmk/plumbing.py
@@ -790,12 +790,13 @@ class Fuzzer(object):
         if not self.__is_started():
             signal.signal(signal.SIGINT, signal.SIG_IGN)
 
+            self.lg.start()
+
             ok = self._load_data_model()
             if not ok:
                 self.set_error("Project cannot be launched because of data model loading error")
                 return
 
-            self.lg.start()
             try:
                 ok = self.tg._start()
             except:


### PR DESCRIPTION
I moved `lg.start()` because an exception was raised when I tried to run `python fuzzfmk/test.py`

>   File ".... fuddly/fuzzfmk/logger.py", line 622, in log_error
>     self.fmkDB.insert_fmk_info(self.last_data_id, msg, now, error=True)
> AttributeError: 'Logger' object has no attribute 'last_data_id'
