### PR TITLE
Add config entries for the Term class

### DIFF
--- a/framework/config.py
+++ b/framework/config.py
@@ -67,7 +67,6 @@ default.add('FmkPlumbing', u'''
 config_name: FmkPlumbing
 
 [misc]
-external_term = False
 fuzz.delay = 0
 fuzz.burst = 1
 
@@ -82,6 +81,27 @@ empty_tg.verbose = False
 ;;  [targets.doc]
 ;;  self: configuration related to targets
 ;;  empty_tg.verbose: Enable verbose mode (if True) on the default EmptyTarget()
+
+[terminal]
+external_term = False
+name=x-terminal-emulator
+title_arg=--title
+hold_arg=--hold
+exec_arg=-e
+exec_arg_type=string
+extra_args=
+
+;; [terminal.doc]
+;; self: Configuration applicable to the external terminal
+;; external_term: Use an external terminal
+;; name: Command to call the terminal
+;; title_arg: Option used by the terminal to set the title
+;; hold_arg: Options to keep the terminal open after the commands exits
+;; exec_arg: Option to specify the program to be run by the terminal
+;; exec_arg_type: How the command should be passed on the command line, can be 
+                    string if the command and it's arguments are to be passed as one string or
+                    list if they are to be individual arguments
+;; extra_args: Extra argument to pass on the command line
 
 ''')
 

--- a/framework/database.py
+++ b/framework/database.py
@@ -34,7 +34,7 @@ import framework.global_resources as gr
 import libs.external_modules as em
 from framework.knowledge.feedback_collector import FeedbackSource
 from libs.external_modules import *
-from libs.utils import ensure_dir, chunk_lines
+from libs.utils import chunk_lines
 
 
 def regexp(expr, item):
@@ -1095,7 +1095,7 @@ class Database(object):
                     did=data_id)
 
                 export_full_fn = os.path.join(base_dir, dm_name, export_fname)
-                ensure_dir(export_full_fn)
+                gr.ensure_dir(export_full_fn)
 
                 with open(export_full_fn, 'wb') as fd:
                     fd.write(content)

--- a/framework/global_resources.py
+++ b/framework/global_resources.py
@@ -35,8 +35,15 @@ except ModuleNotFoundError:
     xdg_data_home = os.path.expanduser('~' + os.sep + 'fuddly_data' + os.sep)
     xdg_config_home = os.path.expanduser('~' + os.sep + 'fuddly_data' + os.sep + "config")
 
-import framework
-from libs.utils import ensure_dir, ensure_file
+# TODO: Taken out of libs.utils, is this the best place for them?
+def ensure_dir(f):
+    d = os.path.dirname(f)
+    if not os.path.exists(d):
+        os.makedirs(d)
+
+def ensure_file(f):
+    if not os.path.isfile(f):
+        open(f, 'a').close()
 
 
 fuddly_version = '0.27.2'

--- a/framework/knowledge/feedback_handler.py
+++ b/framework/knowledge/feedback_handler.py
@@ -64,17 +64,15 @@ class FeedbackHandler(object):
     A feedback handler extract information from binary data.
     """
 
-    def __init__(self, new_window=False, new_window_title=None, xterm_prg_name='x-terminal-emulator'):
+    def __init__(self, new_window=False, new_window_title=None):
         """
         Args:
             new_window: If `True`, a new terminal emulator is created, enabling the decoder to use
               it for display via the methods `print()` and `print_nl()`
 
-            xterm_prg_name: name of the terminal emulator program to be started
         """
         self._new_window = new_window
         self._new_window_title = new_window_title
-        self._xterm_prg_name = xterm_prg_name
         self._s = None
         self.term = None
         self.fmkops = None
@@ -133,8 +131,7 @@ class FeedbackHandler(object):
         self._s = ''
         if self._new_window:
             nm = self.__class__.__name__ if self._new_window_title is None else self._new_window_title
-            self.term = Term(name=nm, xterm_prg_name=self._xterm_prg_name,
-                             keepterm=True)
+            self.term = Term(title=nm, keepterm=True)
             self.term.start()
 
         self.start(current_dm)

--- a/framework/logger.py
+++ b/framework/logger.py
@@ -37,7 +37,7 @@ from framework.data import Data
 from framework.global_resources import *
 from framework.database import Database
 from framework.knowledge.feedback_collector import FeedbackSource
-from libs.utils import ensure_dir, ExternalDisplay, Accumulator
+from libs.utils import ExternalDisplay, Accumulator
 import framework.global_resources as gr
 
 class Logger(object):
@@ -721,7 +721,7 @@ class Logger(object):
 
         export_full_fn = os.path.join(base_dir, dm_name, export_fname)
 
-        ensure_dir(export_full_fn)
+        gr.ensure_dir(export_full_fn)
 
         fd = open(export_full_fn, 'wb')
         fd.write(data.to_bytes())

--- a/framework/plumbing.py
+++ b/framework/plumbing.py
@@ -276,7 +276,7 @@ class FmkPlumbing(object):
         self._quiet = quiet
         self.external_display = ExternalDisplay()
         if external_term:
-            self.external_display.start_term(name='Fuddly log', keepterm=True)
+            self.external_display.start_term(title='Fuddly log', keepterm=True)
 
         self.printer = Printer(self)
         self.print = self.printer.print
@@ -364,7 +364,7 @@ class FmkPlumbing(object):
                 self.config.write(cfile)
         atexit.register(save_config)
 
-        external_term = self.config.misc.external_term
+        external_term = self.config.terminal.external_term
         if external_term and not self.external_display.is_enabled:
             self.switch_term()
 
@@ -417,7 +417,7 @@ class FmkPlumbing(object):
 
     def switch_term(self):
         if not self.external_display.is_enabled:
-            self.external_display.start_term(name='Fuddly log', keepterm=False)
+            self.external_display.start_term(title='Fuddly log', keepterm=False)
         else:
             self.external_display.stop()
 


### PR DESCRIPTION
To handle a wider range of terminals with incompatible argument conventions, the previously hardcoded values are now configurable.

They are grouped in the new `terminal` section in `FmkPlumbing.ini` It might not be the best place to put them, but a whole new configuration file for so few options seems a bit overkill.

Said options are as follow:
```
[terminal]
external_term = False
name=x-terminal-emulator
title_arg=--title
hold_arg=--hold
exec_arg=-e
#This can be string or list
exec_arg_type=string
extra_args=
```