### PR TITLE
Properly check if a module exists before using it

### DIFF
--- a/src/fuddly/cli/run.py
+++ b/src/fuddly/cli/run.py
@@ -20,11 +20,14 @@ def get_scripts() -> list():
 
     # Third party/modules
     for ep in entry_points(group=gr.ep_group_names["projects"]):
-        p = find_spec(ep.module).origin
-        if p is None:
+        m = find_spec(ep.module)
+        # An entry point does not actually point to a module 
+        # i.e. somebody broke there package
+        if m is None or m.origin is None:
             # the entry point is not a module, let's just ignore it
             print(f"*** {ep.module} is not a python module, check your installed modules ***")
             continue
+        p = m.origin
 
         if os.path.basename(p) == "__init__.py":
             p=os.path.dirname(p)


### PR DESCRIPTION
If an entry point exists but the module it points to does not, this crashes the fuddly cli.
This break the whole cli and not just the run command, because of the way the completion code works (the function that gives the list of available modules to the main completer function is executed even if not needed)