### PR TITLE
Syntax cleanup in the cli submodule

### DIFF
--- a/src/fuddly/cli/__init__.py
+++ b/src/fuddly/cli/__init__.py
@@ -23,19 +23,19 @@
 ################################################################################
 
 import sys
-import os
 import fuddly.cli.argparse_wrapper as argparse
 import importlib
 
-import argcomplete 
-from argcomplete.completers import ChoicesCompleter, SuppressCompleter
+import argcomplete
 
+# TODO script_argument_completer will be used once a sub-script argument completion logic is developped
 from .run import get_scripts, script_argument_completer
+# TODO tool_argument_completer will be used once a sub-script argument completion logic is developped
 from .tool import get_tools, tool_argument_completer
 
 from typing import List
-from fuddly.cli import * 
 from fuddly.cli.error import CliException
+
 
 def main(argv: List[str] = None):
     # This is done so you can call it from python shell if you want to
@@ -43,7 +43,7 @@ def main(argv: List[str] = None):
     #
     #   main(["run", "some_script", "some", "important args"])
     #    or
-    #   main("run some_script some important args") 
+    #   main("run some_script some important args")
     #
     #   This second for can not have space in the arguments, but so be it...
     #
@@ -51,11 +51,11 @@ def main(argv: List[str] = None):
         case None:
             argv = sys.argv[1:]
         case str():
-            argv=argv.split(" ")
+            argv = argv.split(" ")
 
     parsers = {}
     arg_parser = parsers["main"] = argparse.ArgumentParser(
-            prog="fuddly", 
+            prog="fuddly",
             description="the fuddly cli interface",
             epilog="use 'fuddly <action>' help more information on their arguments",
             exit_on_error=False
@@ -83,7 +83,7 @@ def main(argv: List[str] = None):
         )
 
     with subparsers.add_parser("run", help="run a fuddly project script") as p:
-        # XXX Should you be able to run script from outside the script dir(s?) ?
+        # XXX Should you be able to run script from outside the script dirs?
         parsers["run"] = p
 
         p.add_argument(
@@ -104,7 +104,7 @@ def main(argv: List[str] = None):
             "args",
             nargs=argparse.REMAINDER,
             help="arguments to pass through to the script",
-        ).completer = script_argument_completer
+        )  # .completer = script_argument_completer
 
     with subparsers.add_parser("new", help="create a new project or data model") as p:
         parsers["new"] = p
@@ -123,9 +123,9 @@ def main(argv: List[str] = None):
             help="create a python package project structure"
         )
         p.add_argument(
-            "object", 
-            choices=["dm", "data-model", "project:bare", "project:exemple" ], 
-            metavar = "object",
+            "object",
+            choices=["dm", "data-model", "project:bare", "project:exemple"],
+            metavar="object",
             help="type of object to create. [dm, data-model, project]",
         )
         p.add_argument(
@@ -141,11 +141,13 @@ def main(argv: List[str] = None):
             help="name of the tool to launch, the special value \"list\" list available tools",
             choices=["list", *get_tools()],
         )
+        # TODO add arg completion for tools
         p.add_argument(
             "args",
             nargs=argparse.REMAINDER,
             help="arguments to passthrough to the tool",
-        ).completer = tool_argument_completer
+            # TODO Add back when something is implemented
+        )  # .completer = tool_argument_completer
 
     with subparsers.add_parser("workspace", help="manage fuddly's workspace") as p:
         parsers["workspace"] = p
@@ -166,7 +168,7 @@ def main(argv: List[str] = None):
         argcomplete.autocomplete(arg_parser)
         args = arg_parser.parse_args(args=argv)
     except argparse.ArgumentError as e:
-        print(e.message) 
+        print(e.message)
         print()
         arg_parser.print_help()
         return 0

--- a/src/fuddly/cli/run.py
+++ b/src/fuddly/cli/run.py
@@ -11,6 +11,7 @@ import argcomplete
 # We are part of fuddly so using an internal function is fine:
 from fuddly.framework.plumbing import _populate_projects as populate_projects
 
+
 def get_scripts() -> list():
     # The function is called for when the CLI is called and if we use the list option
     # having paths be an attribute to the functions means we will not run it twice
@@ -19,7 +20,7 @@ def get_scripts() -> list():
     else:
         get_scripts.paths = []
 
-    project_modules=[]
+    project_modules = []
 
     # User scripts
     projects = populate_projects(gr.user_projects_folder, prefix="user_projects", projects=None)
@@ -29,7 +30,7 @@ def get_scripts() -> list():
             m = find_spec(prefix+name)
             # This should never happen
             if m is None or m.origin is None:
-                print(f"{prefx+name} detected as a module in {gr.fuddly_data_folder}/user_projects,"
+                print(f"{prefix+name} detected as a module in {gr.fuddly_data_folder}/user_projects,"
                       " but could not be imported")
                 continue
             project_modules.append(m)
@@ -48,7 +49,7 @@ def get_scripts() -> list():
     for m in project_modules:
         p = m.origin
         if os.path.basename(p) == "__init__.py":
-            p=os.path.dirname(p)
+            p = os.path.dirname(p)
         else:
             # Ignoring old single-files projects
             continue
@@ -59,17 +60,19 @@ def get_scripts() -> list():
 
     return get_scripts.paths
 
-get_scripts.paths=None
+
+get_scripts.paths = None
+
 
 def script_from_pkg_name(name) -> str:
     # pkg_name.script.name -> ("pkg_name.script", "name.py")
     *pkg, file = name.split('.')
-    file+=".py"
-    pkg=".".join(pkg)
+    file += ".py"
+    pkg = ".".join(pkg)
 
     # User scripts
     if pkg.startswith("fuddly.projects_scripts"):
-        path=os.path.join(gr.fuddly_data_folder, "projects_scripts", file)
+        path = os.path.join(gr.fuddly_data_folder, "projects_scripts", file)
         if os.path.isfile(path):
             return path
         else:
@@ -77,7 +80,7 @@ def script_from_pkg_name(name) -> str:
 
     # Third party/module scripts
     try:
-        path=find_spec(name).origin
+        path = find_spec(name).origin
     except ModuleNotFoundError:
         return None
     except AttributeError:
@@ -107,7 +110,7 @@ def start(args: argparse.Namespace):
         return 0
 
     script = script_from_pkg_name(args.script)
-    if script == None:
+    if script is None:
         print(f"Script {args.script} not foud")
         sys.exit(1)
 
@@ -120,4 +123,3 @@ def start(args: argparse.Namespace):
 
     argv.insert(0, executor)
     os.execvp(executor, argv)
-

--- a/src/fuddly/cli/shell.py
+++ b/src/fuddly/cli/shell.py
@@ -1,7 +1,8 @@
 import fuddly.cli.argparse_wrapper as argparse
+from fuddly.framework.plumbing import FmkPlumbing, FmkShell
+
 
 def start(args: argparse.Namespace):
-    from fuddly.framework.plumbing import FmkPlumbing,FmkShell
     fmkdb = args.fmkdb
     external_display = args.external_display
     quiet = args.quiet

--- a/src/fuddly/cli/tool.py
+++ b/src/fuddly/cli/tool.py
@@ -1,13 +1,17 @@
 import fuddly.cli.argparse_wrapper as argparse
 
+from fuddly.cli.error import CliException
+
 import importlib
 import sys
 import argcomplete
 
+
 def get_tools() -> list():
     import pkgutil
-    tools=importlib.import_module("fuddly.tools")
+    tools = importlib.import_module("fuddly.tools")
     return list(map(lambda x: x.name, pkgutil.walk_packages(tools.__path__)))
+
 
 def tool_argument_completer(prefix, parsed_args, **kwargs):
     # Set _ARC_DEBUG in the shell fro _DEBUG to be true
@@ -20,6 +24,7 @@ def tool_argument_completer(prefix, parsed_args, **kwargs):
     else:
         return []
 
+
 def start(args: argparse.Namespace) -> int:
     if args.tool is None:
         raise CliException("Missing tool name")
@@ -29,7 +34,7 @@ def start(args: argparse.Namespace) -> int:
             print(i)
         return 0
 
-    sys.argv = [ args.tool, *args.args]
+    sys.argv = [args.tool, *args.args]
 
     try:
         pkg = importlib.util.find_spec(f"fuddly.tools.{args.tool}")

--- a/src/fuddly/cli/workspace.py
+++ b/src/fuddly/cli/workspace.py
@@ -1,10 +1,11 @@
 import fuddly.cli.argparse_wrapper as argparse
-from .error import  CliException
+from fuddly.cli.error import CliException
 from fuddly.framework import global_resources as gr
 from pathlib import Path
 import subprocess
 import sys
 import os
+
 
 def clean_workspace(path):
     for path_, dirs, files in os.walk(path):
@@ -12,32 +13,32 @@ def clean_workspace(path):
         list(map(lambda f: (path/f).unlink(), files))
         list(map(lambda d: clean_workspace(path/d), dirs))
         dirs.clear()
-        p.rmdir()
+        path.rmdir()
+
 
 def start(args: argparse.Namespace) -> int:
     # Lol, the argument is always in clean 🙃
     if args.clean:
-            (_, folders, files) = next(Path(gr.workspace_folder).walk())
-            if len(files) > 0 or len(folders) > 0:
-                print("The workspace contains the folowing files:")
-                subprocess.run(["tree", gr.workspace_folder], stdout=sys.stdout)
-                match input("Remove? [y/N]"):
-                    case "y"|"Y":
-                        clean_workspace(gr.workspace_folder)
-                        # Recreating the folder
-                        Path(gr.workspace_folder).mkdir()
-                    case _:
-                        print("Canceled")
-            else:
-                print("Workspace empty")
+        (_, folders, files) = next(Path(gr.workspace_folder).walk())
+        if len(files) > 0 or len(folders) > 0:
+            print("The workspace contains the folowing files:")
+            subprocess.run(["tree", gr.workspace_folder], stdout=sys.stdout)
+            match input("Remove? [y/N]"):
+                case "y" | "Y":
+                    clean_workspace(gr.workspace_folder)
+                    # Recreating the folder
+                    Path(gr.workspace_folder).mkdir()
+                case _:
+                    print("Canceled")
+        else:
+            print("Workspace empty")
     elif args.show:
         # Print the path as an OSC-8 link
         # Copliant terminals, should ignore the escape sequence if they don't understand it.
         print("\033]8;;", end="")
-        print(gr.workspace_folder, end="") 
+        print(gr.workspace_folder, end="")
         print("\033\\", end="")
-        print(gr.workspace_folder, end="") 
+        print(gr.workspace_folder, end="")
         print("\033]8;;\033\\")
     else:
-        raise CliException("One of --clean or --show is required")
-
+        raise CliException("Either --clean or --show is required")


### PR DESCRIPTION
Also removes the stub completion function for tools and script arguments as it didn't complete anything for now and prevented the shell from using it's default of suggesting paths

Line length warnings have not been taken into account because being going a little over 80 chars is fine...