### PR TITLE
Remove return from finally since it can be a footgun

### DIFF
--- a/src/fuddly/framework/node.py
+++ b/src/fuddly/framework/node.py
@@ -8586,8 +8586,7 @@ class Node(object):
             val = eval("{!a}".format(val))
         except:
             val = repr(val)
-        finally:
-            return val
+        return val
 
     def _tobytes(self, conf=None, recursive=True):
         def tobytes_helper(node_internals):


### PR DESCRIPTION
Python 3.14 show a warning for returns in finally blocks, which is warranted since they have a somewhat unexpected behaviour https://adamj.eu/tech/2025/08/29/python-fix-syntaxwarning-finally/
(In this case, the return wasn't a problem, but keeping it out of the try-except-finally block is preferable to prevent futur problems)