### PR TITLE
Project conf

### DIFF
--- a/src/fuddly/cli/__init__.py
+++ b/src/fuddly/cli/__init__.py
@@ -35,7 +35,7 @@ from fuddly.cli.tool import tool_argument_completer
 from fuddly.cli.utils import (
         get_projects,
         get_tools,
-        get_all_objects,
+        get_all_object_names,
         get_project_scripts,
 )
 from fuddly.cli.error import CliException
@@ -174,7 +174,7 @@ def main(argv: List[str] = None):
                 "--clone",
                 metavar="object_name",
                 help="name of the object to clone.",
-                choices=["list", *get_all_objects()],
+                choices=["list", *get_all_object_names()],
             )
             g.add_argument(
                 "--type",

--- a/src/fuddly/cli/new.py
+++ b/src/fuddly/cli/new.py
@@ -26,6 +26,8 @@ conf["project"] = {
         {"name": "prj.py"},
         {"name": "monitoring.py"},
         {"name": "targets.py"},
+        {"name": "conf.py", "interpolate": ["name"]},
+        {"name": "README"},
         {"name": "README", "path": "samples"},
         {"name": "README", "path": "scripts"},
     ],

--- a/src/fuddly/cli/new.py
+++ b/src/fuddly/cli/new.py
@@ -80,8 +80,8 @@ def start(args: argparse.Namespace):
             # This id not ideal, a better solution would be having a list command to show 
             # all the modules (and scripts for that matter)
             if args.clone == "list":
-                for n in get_all_object_names():
-                    print(n)
+                for m in get_all_object_names():
+                    print(m)
                 return 0
             dest_dir = dest_dir / get_module_type(args.clone)
         elif args.type.startswith("project"):
@@ -99,7 +99,7 @@ def start(args: argparse.Namespace):
         dest_dir = dest_dir/args.name
         dest_dir.mkdir(parents=True)
 
-    elif args.type is not None:
+    if args.type is not None:
         match PartialMatchString(args.type):
             case "dm" | "data-model":
                 create_msg = f"Creating new data-model \"{module_name}\""

--- a/src/fuddly/cli/templates/bare/__init__.py_
+++ b/src/fuddly/cli/templates/bare/__init__.py_
@@ -1,2 +1,3 @@
 from .prj import (project, logger)
 from .targets import targets
+from .conf import INFO

--- a/src/fuddly/cli/templates/bare/conf.py_
+++ b/src/fuddly/cli/templates/bare/conf.py_
@@ -1,0 +1,44 @@
+from fuddly.framework.global_resources import Conf, config_folder
+from fuddly.framework.config import config, default as def_config
+
+# When your project is loaded, this will create a config file in
+# your $$XDG_CONFIG_HOME/fuddly directory.
+# You can then reuse values from the config file in you project
+conf_name = "Project_${name}"
+def_config.add(conf_name, f"""
+[global]
+config_name = {conf_name}
+var=Global section value
+
+;; [global.doc]
+;; self: This is documentation for your config file.
+;; Use this to describe what the various entries are for
+;; or however you want
+
+[section]
+var=Value
+
+;;  [section.doc]
+;;  self: You can group parameters in sections like this
+;;
+;;  var: This is the documentation for you var parameter in this section
+
+""")
+
+${name}_conf = config(conf_name, path=[config_folder])
+${name}_conf.save(config_folder)
+conf = Conf(
+    var=${name}_conf.var,
+    var_in_section=${name}_conf.section.var,
+)
+
+INFO = f"""
+${name} project configuration (automatically generated)
+
+The content of INFO is show with the command `fuddly show <project_name>
+
+Here you can use parameter from your config, when the associated files
+is created.
+To show a parameter's value, do: {conf.var} (literally {{var}})
+"""
+

--- a/src/fuddly/cli/templates/bare/prj.py_
+++ b/src/fuddly/cli/templates/bare/prj.py_
@@ -1,6 +1,11 @@
 from fuddly.framework.project import Project
 from fuddly.framework.logger import Logger
+from .conf import conf
 
 project = Project()
 project.default_dm = ["non-existant"]
+
+# This is how you access data from your project's config
+print(conf.var)
+
 logger = Logger()

--- a/src/fuddly/cli/utils.py
+++ b/src/fuddly/cli/utils.py
@@ -5,7 +5,8 @@ from fuddly.libs.fmk_services import (
     get_each_data_model_module,
     get_each_target_module,
 )
-from importlib import import_module
+import importlib
+import types
 
 
 # Return the type a module is of
@@ -20,7 +21,7 @@ def get_module_type(name: str) -> str:
 
 
 # Return a list of all projects, dms, and targets fuddly knows about
-def get_all_objects() -> list():
+def get_all_object_names() -> list[str]:
     modules = []
 
     # Projects
@@ -71,7 +72,7 @@ def get_project_scripts(prefix: str, parsed_args: (object | str), **kwargs) -> l
 
 
 # Return a list of projects fuddly knows about
-def get_projects() -> list():
+def get_projects() -> list[importlib.machinery.ModuleSpec]:
     modules = []
 
     project_modules = get_each_project_module()
@@ -90,9 +91,9 @@ def get_projects() -> list():
 
 
 # Return a list of all the fuddly tools
-def get_tools() -> list():
+def get_tools() -> list[types.ModulesType]:
     import pkgutil
     modules = []
-    tools = import_module("fuddly.tools")
+    tools = importlib.import_module("fuddly.tools")
     modules = list(map(lambda x: x.name, pkgutil.walk_packages(tools.__path__)))
     return modules

--- a/src/fuddly/libs/fmk_services.py
+++ b/src/fuddly/libs/fmk_services.py
@@ -9,7 +9,7 @@ from fuddly.framework.plumbing import _populate_projects as populate_projects
 
 
 # Get all modules (from FS and entry_points)
-def get_module_of_type(group_name: str, prefix: str):
+def get_module_of_type(group_name: str, prefix: str) -> list[importlib.machinery.ModuleSpec]:
     path = {
         "targets": gr.user_targets_folder,
         "projects": gr.user_projects_folder,
@@ -23,21 +23,21 @@ def get_module_of_type(group_name: str, prefix: str):
     return modules
 
 
-def get_each_project_module() -> list():
+def get_each_project_module() -> list[importlib.machinery.ModuleSpec]:
     return get_module_of_type(
             group_name="projects",
             prefix="fuddly/projects"
         )
 
 
-def get_each_data_model_module() -> list():
+def get_each_data_model_module() -> list[importlib.machinery.ModuleSpec]:
     return get_module_of_type(
             group_name="data_models",
             prefix="fuddly/data_models"
         )
 
 
-def get_each_target_module() -> list():
+def get_each_target_module() -> list[importlib.machinery.ModuleSpec]:
     return get_module_of_type(
             group_name="targets",
             prefix="fuddly/targets"
@@ -45,7 +45,7 @@ def get_each_target_module() -> list():
 
 
 # Find python modules in a specific path, prepend "prefix" to the modules' names
-def find_modules_in_dir(path: str, prefix: str) -> list():
+def find_modules_in_dir(path: str, prefix: str) -> list[importlib.machinery.ModuleSpec]:
     res = []
     fullpath = os.path.join(gr.fuddly_data_folder, path)
     # TODO this is the project specific detector which checks if it's a python
@@ -66,7 +66,7 @@ def find_modules_in_dir(path: str, prefix: str) -> list():
 
 
 # Get all the python modules corresponding to a certain entry_point name group
-def find_modules_from_ep_group(group_name: str) -> list():
+def find_modules_from_ep_group(group_name: str) -> list[importlib.machinery.ModuleSpec]:
     res = []
     for ep in entry_points(group=group_name):
         if ep.name.endswith("__root__"):


### PR DESCRIPTION
Add a "conf.py" to the `project:bare` template.
The first commit fixes a bug introduced by one of the previous PRs on the cli (run rework or `--clone` option) and adds a bit more type hinting.