### PR TITLE
Replace deprecated importlib.ModuleSpec.loader.load_module function

### DIFF
--- a/src/fuddly/cli/tool.py
+++ b/src/fuddly/cli/tool.py
@@ -35,5 +35,9 @@ def start(args: argparse.Namespace) -> int:
     if pkg is None:
         print(f"{args.tool} is not a valid fuddly tool")
         return 1
-    mod = pkg.loader.load_module()
+    mod = importlib.util.module_from_spec(pkg)
+    if mod is None:
+        print(f"{args.tool} is not a valid fuddly tool")
+        return 1
+    pkg.loader.exec_module(mod)
     return mod.main()


### PR DESCRIPTION
The functions documentation states that it is deprecated and the exec module needs to be used instead.