### PR TITLE
Config

### DIFF
--- a/docs/source/packaging.rst
+++ b/docs/source/packaging.rst
@@ -47,7 +47,7 @@ See :ref:`dm:mydf` for the implementation.
 A special value in the entry_points needs to be added for `fuddly` to be able to find where the root of your module is.
 The name should end in `__root__`, the first part will be used during imports.
 With the example above, you would import the module with ``import fuddly.data_models.modulename.mydf``.
-It's value should point to the namespace in which the module can be found. This is usually the parent directory to 
+Its value should point to the namespace in which the module can be found. This is usually the parent directory to 
 your data_model, project, target or info.
 In case of a package containing only your module, the name of the module should be used.
 

--- a/src/fuddly/cli/__init__.py
+++ b/src/fuddly/cli/__init__.py
@@ -202,7 +202,6 @@ def main(argv: List[str] = None):
             "--dest",
             metavar="PATH",
             type=argparse.PathType(
-                dash_ok=False,
                 type="dir"
             ),
             help="directory to create the object in.",
@@ -318,7 +317,6 @@ def main(argv: List[str] = None):
             dest='file_path',
             metavar="FILE_PATH",
             type=argparse.PathType(
-                dash_ok=False,
                 type="file"
             ),
             help="optional file path from which data to decode shall be retrieved",

--- a/src/fuddly/cli/argparse_wrapper.py
+++ b/src/fuddly/cli/argparse_wrapper.py
@@ -1,4 +1,6 @@
 import argparse
+# This wildcard import makes this module contains everything from the original
+# argpars making it a drop-in replacement
 from argparse import *
 import os
 
@@ -25,57 +27,47 @@ contextualize(argparse.ArgumentParser)
 # Taken from https://mail.python.org/pipermail/stdlib-sig/2015-July/000990.html
 # Replaced string interpolation with f-strings and syntax tweak
 class PathType(object):
-    def __init__(self, exists=True, type='file', dash_ok=True):
+    def __init__(self, exists=True, type='file'):
         '''exists:
                 True: a path that does exist
                 False: a path that does not exist, in a valid parent directory
                 None: don't care
            type: file, dir, symlink, None, or a function returning True for valid paths
                 None: don't care
-           dash_ok: whether to allow "-" as stdin/stdout'''
+        '''
 
         assert exists in (True, False, None)
         assert type in ('file', 'dir', 'symlink', None) or hasattr(type, '__call__')
 
         self._exists = exists
         self._type = type
-        self._dash_ok = dash_ok
 
     def __call__(self, string):
-        if string == '-':
-            # the special argument "-" means sys.std{in,out}
-            if self._type == 'dir':
-                raise ArgumentTypeError('standard input/output (-) not allowed as directory path')
+        e = os.path.exists(string)
+        if self._exists is True:
+            if not e:
+                raise ArgumentTypeError(f"path does not exist: '{string}'")
+            if self._type is None:
+                pass
+            elif self._type == 'file':
+                if not os.path.isfile(string):
+                    raise ArgumentTypeError(f"path is not a file: '{string}'")
             elif self._type == 'symlink':
-                raise ArgumentTypeError('standard input/output (-) not allowed as symlink path')
-            elif not self._dash_ok:
-                raise ArgumentTypeError('standard input/output (-) not allowed')
+                if not os.path.islink(string):
+                    raise ArgumentTypeError(f"path is not a symlink: '{string}'")
+            elif self._type == 'dir':
+                if not os.path.isdir(string):
+                    raise ArgumentTypeError(f"path is not a directory: '{string}'")
+            elif not self._type(string):
+                raise ArgumentTypeError(f"path not valid: '{string}'")
         else:
-            e = os.path.exists(string)
-            if self._exists is True:
-                if not e:
-                    raise ArgumentTypeError(f"path does not exist: '{string}'")
-                if self._type is None:
-                    pass
-                elif self._type == 'file':
-                    if not os.path.isfile(string):
-                        raise ArgumentTypeError(f"path is not a file: '{string}'")
-                elif self._type == 'symlink':
-                    if not os.path.symlink(string):
-                        raise ArgumentTypeError(f"path is not a symlink: '{string}'")
-                elif self._type == 'dir':
-                    if not os.path.isdir(string):
-                        raise ArgumentTypeError(f"path is not a directory: '{string}'")
-                elif not self._type(string):
-                    raise ArgumentTypeError(f"path not valid: '{string}'")
-            else:
-                if self._exists is False and e:
-                    raise ArgumentTypeError(f"path exists: '{string}'")
+            if self._exists is False and e:
+                raise ArgumentTypeError(f"path exists: '{string}'")
 
-                p = os.path.dirname(os.path.normpath(string)) or '.'
-                if not os.path.isdir(p):
-                    raise ArgumentTypeError(f"parent path is not a directory: '{p}'")
-                elif not os.path.exists(p):
-                    raise ArgumentTypeError(f"parent directory does not exist: '{p}'")
+            p = os.path.dirname(os.path.normpath(string)) or '.'
+            if not os.path.isdir(p):
+                raise ArgumentTypeError(f"parent path is not a directory: '{p}'")
+            elif not os.path.exists(p):
+                raise ArgumentTypeError(f"parent directory does not exist: '{p}'")
 
         return string

--- a/src/fuddly/cli/new.py
+++ b/src/fuddly/cli/new.py
@@ -65,7 +65,11 @@ def start(args: argparse.Namespace):
     clone = False
     # TODO should the template dir be in fuddly_folder so users can define their own templates?
     # origin is the __init__.py file of the module so taking "parent" gives us the module folder
-    src_dir = Path(util.find_spec("fuddly.cli").origin).parent.joinpath("templates")
+    spec = util.find_spec("fuddly.cli")
+    if spec is None:
+        print("Failed to get the spec of the 'fuddly.cli' module.")
+        return 1
+    src_dir = Path(spec.origin).parent.joinpath("templates")
     module_name = args.name
 
     if args.clone is not None and args.pyproject:

--- a/src/fuddly/framework/config.py
+++ b/src/fuddly/framework/config.py
@@ -1,8 +1,4 @@
-##############################################################################
-#
-#  Copyright 2017 Matthieu Daumas <matthieu@daumas.me>
-#
-##############################################################################
+################################################################################
 #
 #  This file is part of fuddly.
 #
@@ -19,37 +15,24 @@
 #  You should have received a copy of the GNU General Public License
 #  along with fuddly. If not, see <http://www.gnu.org/licenses/>
 #
-##############################################################################
+################################################################################
 
-# TODO: dump the whole code
-# TODO: rewrite a proper module without configparser, nor "textual" backend
-# TODO: write a backend to write config objects to files
-# TODO: document it
-#
-# Features:
-# - configparser-enabled (sic)
-# - transparent access to the config keys
-# - inline documentation of the config keys
-# - recursive pattern/mergeable configs
-#
-
-import io
 import os
 import re
 import sys
-
 import configparser
 
+from collections.abc import Iterator
 from fuddly.framework.global_resources import config_folder
 
-reserved = {'config_name', 'parser', 'help', 'write', 'global', '_config_changed'}
 verbose = False
 
 
-class default:
+class Default:
     def __init__(self):
         self.configs = {}
 
+    # TODO when all known default configs have been updated, this can be removed
     __unindent = re.compile(r'^;;\s\s*', re.MULTILINE)
 
     def _unindent(self, multiline):
@@ -59,7 +42,7 @@ class default:
         self.configs[name] = self._unindent(doc)
 
 
-default = default()
+default = Default()
 
 default.add("FmkPlumbing", """
 [global]
@@ -70,32 +53,32 @@ fuzz.delay = 0
 fuzz.burst = 1
 continuous_monitoring_mode = True
 
-;;  [misc.doc]
-;;  self: (default values used when the framework resets)
-;;  fuzz.delay: Default value (> 0) for fuzz_delay
-;;  fuzz.burst: Default value (>= 1) for fuzz_burst
+[misc.doc]
+self: (default values used when the framework resets)
+fuzz.delay: Default value (> 0) for fuzz_delay
+fuzz.burst: Default value (>= 1) for fuzz_burst
 
 [targets]
 empty_tg.verbose = False
 
-;;  [targets.doc]
-;;  self: configuration related to targets
-;;  empty_tg.verbose: Enable verbose mode (if True) on the default EmptyTarget()
+[targets.doc]
+self: configuration related to targets
+empty_tg.verbose: Enable verbose mode (if True) on the default EmptyTarget()
 
 [terminal]
 external_term = False
 cmd = x-terminal-emulator -p tabtitle={title} -e {cmd}
 hold_arg = --hold
 
-;;  [terminal.doc]
-;;  self: Configuration applicable to the external terminal
-;;  external_term: Use an external terminal
-;;  cmd: Command to call the terminal.
-          It will be used as a python format string.
-          {title} will be replaces by the terminal title,
-          {hold} will be replaced with hold_arg if the terminal is to be kept open
-          {cmd} is the command that will be executed in the terminal
-;;  hold_arg: Options to keep the terminal open after the commands exits
+[terminal.doc]
+self: Configuration applicable to the external terminal
+external_term: Use an external terminal
+cmd: Command to call the terminal.
+      It will be used as a python format string.
+      {title} will be replaces by the terminal title,
+      {hold} will be replaced with hold_arg if the terminal is to be kept open
+      {cmd} is the command that will be executed in the terminal
+hold_arg: Options to keep the terminal open after the commands exits
 
 """)
 
@@ -112,31 +95,31 @@ offline_doc = True
 inline_doc = False
 dmaker_short_desc = False
 
-;;  [completion.doc]
-;;  offline_doc: When set to True, documentation for Generators and Operators are
-                  are displayed (while being completed by the shell) on the external terminal
-                  if it is enabled (either via with the config parameter 'external_term' set
-                  to True in 'FmkPlumbing.ini', or by launching the fuddly shell with the
-                  option '--external-display').
-                  Besides, description of their parameters are also displayed on the external
-                  terminal while being completed by the shell.
-;;  inline_doc: When set to True, documentation for Generators and Operators are
-                 displayed inline, as well as description of their parameters when parameters
-                 are being completed by the shell.
-;;  dmaker_short_desc: When set to True, only a short description of data makers (Generators
+[completion.doc]
+offline_doc: When set to True, documentation for Generators and Operators are
+              are displayed (while being completed by the shell) on the external terminal
+              if it is enabled (either via with the config parameter 'external_term' set
+              to True in 'FmkPlumbing.ini', or by launching the fuddly shell with the
+              option '--external-display').
+              Besides, description of their parameters are also displayed on the external
+              terminal while being completed by the shell.
+inline_doc: When set to True, documentation for Generators and Operators are
+             displayed inline, as well as description of their parameters when parameters
+             are being completed by the shell.
+dmaker_short_desc: When set to True, only a short description of data makers (Generators
                         and Operators) will be displayed. Otherwise, full documentation
-                        including parameters will be displayed. 
+                        including parameters will be displayed.
 
 [config]
 middle = 40
 indent.width = 4
 indent.level = 0
 
-;;  [config.doc]
-;;  self: Configuration applicable to the 'config' command
-;;  middle: Set the column where the helpers are defined.
-;;  indent.width: Set the indentation width used to display the helpers.
-;;  indent.level: Set the initial level of indentation width
+[config.doc]
+self: Configuration applicable to the 'config' command
+middle: Set the column where the helpers are defined.
+indent.width: Set the indentation width used to display the helpers.
+indent.level: Set the initial level of indentation width
                     used to display the helpers.
 
 [send_loop]
@@ -145,27 +128,27 @@ aligned_options.batch_mode = False
 aligned_options.hide_cursor = True
 aligned_options.prompt_height = 3
 
-;;  [send_loop.doc]
-;;  self: Configuration applicable to the 'send_loop' command.
-;;
-;;  aligned: Enable aligned display while sending data payloads.
-;;  aligned_options.batch_mode: Enable fitting multiple payloads onscreen
-                     (when using 'send_loop -1 <generator>').
-;;  aligned_options.hide_cursor: Attempt to reduce blinking by hiding cursor.
-;;  aligned_options.prompt_height: Estimation of prompt's height.
+[send_loop.doc]
+self: Configuration applicable to the 'send_loop' command.
+
+aligned: Enable aligned display while sending data payloads.
+aligned_options.batch_mode: Enable fitting multiple payloads onscreen
+                 (when using 'send_loop -1 <generator>').
+aligned_options.hide_cursor: Attempt to reduce blinking by hiding cursor.
+aligned_options.prompt_height: Estimation of prompt's height.
 
 [send]
 reset_dmakers = False
 
-;;  [send.doc]
-;;  self: Configuration applicable to the 'send' command and all derivatives
-          (excluding the loop versions).
-;;
-;;  reset_dmakers: [OBSOLETE] When this property is False, the data makers (Generator and Operators) involved
-      in the send* commands will keep their state, except if new parameters
-      are provided to them. In this case, all the data makers in the command will be reset.
-      When this property is set to True, the data makers involved in the send* commands will be
-      systematically reset before being used.  
+[send.doc]
+self: Configuration applicable to the 'send' command and all derivatives
+      (excluding the loop versions).
+
+reset_dmakers: [OBSOLETE] When this property is False, the data makers (Generator and Operators) involved
+  in the send* commands will keep their state, except if new parameters
+  are provided to them. In this case, all the data makers in the command will be reset.
+  When this property is set to True, the data makers involved in the send* commands will be
+  systematically reset before being used.
 
 
 """)
@@ -178,17 +161,18 @@ config_name = Database
 before_data_id = 5
 after_data_id = 60
 
-;;  [async_data.doc]
-;;  self: Configuration applicable to ASYNC DATA.
-;;
-;;  before_data_id: an async_data (without any associated data_id) will be considered to be related
-      to a data sent afterwards if the number of seconds that separates it from that data is less
-      than the amount specified in this parameter.
-;;  after_data_id: if after the last registered data by the framework, an async data is sent after
-      more than the amount of seconds specified in this parameter, it won't be considered to be
-      related to this last registered data.
+[async_data.doc]
+self: Configuration applicable to ASYNC DATA.
+
+before_data_id: an async_data (without any associated data_id) will be considered to be related
+  to a data sent afterwards if the number of seconds that separates it from that data is less
+  than the amount specified in this parameter.
+after_data_id: if after the last registered data by the framework, an async data is sent after
+  more than the amount of seconds specified in this parameter, it won't be considered to be
+  related to this last registered data.
 
 """)
+
 
 def update_config(from_whom, old_config):
     error_msg = (f"\n[WARNING] Old version detected for '{old_config.config_name}.ini' (renamed)."
@@ -201,366 +185,136 @@ def update_config(from_whom, old_config):
         new_config.write(cfile)
     return new_config, error_msg
 
-def check_type(name, attr, value):
-    original = value
 
-    try:
-        attr = str(attr)
-    except Exception as e:
-        raise AttributeError("unable to cast key's value " +
-                             "'{}' into a string".format(name) + ': ' + str(e))
-
-    try:
-        value = str(value)
-    except Exception as e:
-        raise AttributeError((
-            "unable to cast '{}' " + "for key '{}' into a string").format(
-                value, name) + ': ' + str(e))
-
-    test, value = try_bool(attr, value, name)
-    if test is not None:
-        return value
-
-    test, value = try_int(attr, value, name)
-    if test is not None:
-        return value
-
-    test, value = try_float(attr, value, name)
-    if test is not None:
-        return value
-
-    return original
-
-
-def try_bool(attr, value, name):
+def check_type(name: str, value: str):
     booleans = ["True", "False"]
-    if attr in booleans:
-        test = (attr == "True")
-    else:
-        test = None
-    if test is not None:
-        if value in booleans:
-            return (test, (value == "True"))
-        else:
-            raise AttributeError("key '{}' expects a boolean".format(name))
-
-    return (test, value)
-
-
-def try_int(attr, value, name):
     try:
-        test = int(attr)
-    except BaseException:
-        test = None
-    if test is not None:
-        try:
-            return (test, int(value))
-        except BaseException:
-            raise AttributeError("key '{}' expects an integer".format(name))
+        base = {
+            "0b": 2,
+            "0o": 8,
+            "0x": 16,
+        }[value[0:2]]
+    except KeyError:
+        base = 10
 
-    return (test, value)
+    # booleans
+    if value in booleans:
+        return value == "True"
 
-
-def try_float(attr, value, name):
+    # integers
     try:
-        test = float(attr)
-    except BaseException:
-        test = None
-    if test is not None:
-        try:
-            return (test, float(value))
-        except BaseException:
-            raise AttributeError("key '{}' expects a float".format(name))
-
-    return (test, value)
-
-
-def config_write(that, stream=sys.stdout):
-
-    that_dict = object.__getattribute__(that, '__dict__')
-    subconfigs = []
-    for item in that_dict.items():
-        if isinstance(item[1], config):
-            subconfigs.append(item)
-
-    for name, subconfig in subconfigs:
-        setattr(that, name, subconfig)
-
-    return that.parser.write(stream)
-
-
-def sectionize(that, parent):
-    if parent is not None:
-        that.config_name = parent
-
-    try:
-        name = str(that.config_name)
-    except BaseException:
-        name = that.config_name
-
-    parser = configparser.ConfigParser()
-    resection = re.compile(r'^([^.]*)\.?(.*)')
-    for section in that.parser.sections():
-        match = resection.match(section)
-        if not match:
-            raise RuntimeError("unable to match '{}'".format(section) +
-                               ' section name')
-
-        if len(match.group(2)) > 0:
-            target = name + '.' + match.group(2)
-        else:
-            target = name
-
-        if not parser.has_section(target):
-            parser.add_section(target)
-
-        if match.group(1) == 'global':
-            for option in that.parser.options(section):
-                value = that.parser.get(section, option)
-                parser.set(target, option, value)
-        else:
-            for option in that.parser.options(section):
-                value = that.parser.get(section, option)
-                parser.set(target, match.group(1) + '.' + option, value)
-
-    return parser
-
-
-def get_help_format(line, doc, level, indent, middle):
-    if doc is None or len(doc) < 1:
-        doc = '\n'
-
-    try:
-        line = str(line)
+        return int(value, base=base)
     except BaseException:
         pass
 
-    msg = ''
-    space = ' '
-    lines = line.splitlines(True)
-    for line in lines:
-        line = level * indent * space + line
-        msg += line
-
-        fst = True
-        docs = doc.splitlines(True)
-        for doc in docs:
-            if fst:
-                size = middle - len(line)
-                msg += size * space + doc
-                fst = False
-            else:
-                msg += middle * space + doc
-
-            if not ('\n' in doc):
-                msg += '\n'
-    return msg
-
-
-def get_help_attr(that, name, level=0, indent=4, middle=40):
-    if name in reserved:
-        return get_help_format(name + ': <reserved>',
-                               '(implementation details, reserved)', level,
-                               indent, middle)
-
-    dot_section = re.compile(r'^[^.]+\.[^.]+$')
-    if dot_section.match(name) and that.parser.has_section(name):
-        return get_help_format(name + ': <reserved>',
-                               '(special section, reserved)', level, indent,
-                               middle)
-
-    if that.parser.has_section(name):
-        try:
-            doc = that.parser.get(name + '.doc', 'that')
-        except BaseException:
-            doc = None
-
-        msg = '\n'
-        msg += get_help_format(name + ':', doc, level, indent, middle)
-        return (msg + get_help(
-            getattr(that, name), None, level + 1, indent, middle))
-
+    # floats
     try:
-        doc = that.parser.get('global.doc', name)
+        return float(value)
     except BaseException:
-        doc = None
+        pass
 
-    try:
+    return value
+
+
+class SectionProxyWrapper(configparser.SectionProxy):
+    def __getattr__(self, key: str):
+        # Just ignore all private attributes, that's the easiest
+        if key.startswith("_"):
+            return configparser.SectionProxy.__getattribute__(self, key)
         try:
-            value = str(that.parser.get('global', name))
-        except BaseException:
-            value = that.parser.get('global', name)
-    except BaseException:
-        kdict = object.__getattribute__(that, '__dict__')
-        keys = [key for key in kdict]
-        if name in keys and isinstance(kdict[name], config_dot_proxy):
-            msg = name + ': (subkeys)\n'
-            keys = [key for key in keys if key.startswith(name + '.')]
-            for key in sorted(keys):
-                msg += get_help_attr(that, key, level + 1, indent, middle)
-            return msg
-        else:
-            value = '<undefined>'
+            return self.__getitem__(key)
+        except KeyError:
+            return configparser.SectionProxy.__getattribute__(self, key)
 
-    return get_help_format(name + ': ' + value, doc, level, indent, middle)
+    def __getitem__(self, key: str) -> object:
+        return check_type(key, configparser.SectionProxy.__getitem__(self, key))
 
+    def __setattr__(self, key: str, val: object):
+        return self.__setitem__(key, val)
 
-def get_help(that, name=None, level=0, indent=4, middle=40):
-    if name is not None:
-        return get_help_attr(that, name, level, indent, middle)
+    def __setitem__(self, key: str, val: object):
+        self.parser._config_changed = True
+        return configparser.SectionProxy.__setitem__(self, key, str(val))
 
-    msg = ''
-    resection = re.compile(r'^[^.]*$')
-    for section in that.parser.sections():
-        if section == 'global':
-            for option in that.parser.options(section):
-                if option in reserved:
-                    continue
-                else:
-                    msg += get_help_attr(that, option, level, indent, middle)
-        elif resection.match(section):
-            msg += get_help_attr(that, section, level, indent, middle)
-        else:
+    def fmt_option(self, name, level=0, indent=4, middle=40) -> str:
+        "Format the output for printing the docs of this section/option"
+        if self.name.endswith(".doc"):
+            return ""
+        tab = " " * indent * level  # Level should either 0 or 1
+        val = self[name]
+        line_start = f"{tab}{name}: {val}"
+        description = ""
+        try:
+            description = f"{self.parser[self.name + ".doc"][name]}".replace("\n", "\n" + " " * middle)
+        except Exception:
+            # Ignore missing docs
             pass
+        pad = " " * (middle-(len(line_start)))
+        return line_start + pad + description + "\n"
 
-    return msg
+    def help(self, option: str | None, level=0, indent=4, middle=40) -> str:
+        "Show help for this specific section, or an options in it"
+        try:
+            # Need to go through the parser to get the doc for the section
+            doc_section = self.parser[self.name + ".doc"]
+        except KeyError:
+            return ""
+        if option is not None:
+            if option in self:
+                return self.fmt_option(option, 0, indent, middle)
+            else:
+                # Sub options handling
+                sub_opts = list(filter(lambda o: o.startswith(option + "."), doc_section))
+                if len(sub_opts) == 0:
+                    return f"{option}: <undefined>\n"
 
-
-def config_setattr(that, name, value):
-    try:
-        attr = object.__getattribute__(that, name)
-    except BaseException:
-        attr = None
-
-    if not isinstance(value, config):
-        if isinstance(value, config_dot_proxy):
-            raise RuntimeError("'{}' (config_dot_proxy)".format(name) +
-                               " can not be used as value.")
-
-        if attr is not None:
-            value = check_type(name, attr, value)
-
-        if '.' in name:
-            prefixes = name.split('.')
-            for i in range(1, len(prefixes)):
-                prefix = '.'.join(prefixes[:-1 * i])
-                proxy = config_dot_proxy(that, prefix)
-                object.__setattr__(that, prefix, proxy)
-
-        strvalue = str(value)
-        that.parser.set('global', name, strvalue)
-        object.__setattr__(that, '_config_changed', True)
-        return object.__setattr__(that, name, value)
-
-    if attr is None:
-        flat_parser = sectionize(value, name)
-        for section in flat_parser.sections():
-            if not that.parser.has_section(section):
-                that.parser.add_section(section)
-
-            for option in flat_parser.options(section):
-                if option in reserved:
-                    continue
-                subvalue = flat_parser.get(section, option)
-                that.parser.set(section, option, subvalue)
-
-        return object.__setattr__(that, name, value)
-
-    if not isinstance(attr, config):
-        raise AttributeError("unable to replace key '{}'".format(name) +
-                             " by a section")
-
-    attr_parser = sectionize(attr, name)
-    for section in attr_parser.sections():
-        if not that.parser.has_section(section):
-            continue
-
-        for option in attr_parser.options(section):
-            if option in reserved:
-                continue
-
-            that.parser.remove_option(section, option)
-
-        if len(that.parser.options(section)) < 1:
-            that.parser.remove_section(section)
-
-    object.__setattr__(that, name, None)
-    return setattr(that, name, value)
-
-
-def config_getattribute(that, name):
-    if name == 'help':
-
-        def get_help_proxy(name=None, level=0, indent=4, middle=40):
-            msg = get_help(that, name, level, indent, middle)
-            try:
-                return str(msg)
-            except BaseException:
+                msg = f"{option}: (subkey)\n"
+                level = 1
+                for o in sub_opts:
+                    if o == "self":
+                        continue
+                    msg += self.fmt_option(o, level, indent, middle)
                 return msg
 
-        return get_help_proxy
+        msg = ''
+        # If in the global section, don't show the section name, and don't indent
+        if self.name != "global":
+            msg += f"{self.name}:\n"
+            level = 1
 
-    if name == 'write':
+        if self.name + ".doc" not in self.parser:
+            return ""
 
-        def write_proxy(stream=sys.stdout):
-            return config_write(that, stream)
-
-        return write_proxy
-
-    try:
-        attr = object.__getattribute__(that, name)
-        try:
-            attr = check_type(name, attr, attr)
-        except BaseException:
-            pass
-    except BaseException:
-        attr = None
-
-    if attr is None or '__' in name[:2] or '_config__' in name[:9]:
-        msg = "'config' instance for '{}' has no key nor section '{}'"
-        if not name == 'config_name':
-            raise AttributeError(msg.format(that.config_name, name))
-        else:
-            raise AttributeError(msg.format('error', name))
-
-    return attr
+        for opt in doc_section:
+            if opt == "self":
+                continue
+            msg += self.fmt_option(opt, level, indent, middle)
+        return msg
 
 
-class config_dot_proxy(object):
-    def __init__(self, config, prefix):
-        object.__setattr__(self, 'parent', config)
-        object.__setattr__(self, 'prefix', prefix)
+class ConfigParser(configparser.ConfigParser):
+    def __init__(self,
+                 parent: object,
+                 path=['.'],
+                 ext=['.ini', '.conf', '.cfg'],
+                 *args,
+                 **kwargs):
 
-    def __getattribute__(self, name):
-        parent = object.__getattribute__(self, 'parent')
-        prefix = object.__getattribute__(self, 'prefix')
-        try:
-            return getattr(parent, prefix + '.' + name)
-        except BaseException:
-            return config_dot_proxy(self, name)
+        # Need to call the real setter to not get into a recursion loop
+        object.__setattr__(self, "_initialised", False)
+        super().__init__(*args, **kwargs)
 
-    def __setattr__(self, name, value):
-        parent = object.__getattribute__(self, 'parent')
-        prefix = object.__getattribute__(self, 'prefix')
-        return setattr(parent, prefix + '.' + name, value)
-
-
-class config(object):
-
-    def __init__(self, parent, path=['.'], ext=['.ini', '.conf', '.cfg']):
-
-        object.__setattr__(self, 'parser', configparser.ConfigParser())
+        loaded = False
         loaded_from_default = False
 
         if isinstance(parent, str):
             name = parent
         else:
-            try:
-                name = parent.__class__.__name__
-            except BaseException:
-                name = parent.__name__  # (no parent.__class__.__name__)
+            name = parent.__class__.__name__
 
-        loaded = False
+        self.name = name
+
+        # Select the first file matching name.ext in one of path
         for pdir in path:
             if not os.path.isdir(pdir):
                 continue
@@ -568,114 +322,95 @@ class config(object):
                 filename = os.path.join(pdir, name + pext)
                 if not os.path.isfile(filename):
                     continue
-
                 try:
                     if verbose:
-                        sys.stderr.write('Loading {}...\n'.format(filename))
+                        sys.stderr.write(f"Loading {filename}...\n")
                     with open(filename, 'r') as cfile:
-                        self.parser.read_file(cfile, source=filename)
+                        self.read_file(cfile, source=filename)
                     loaded = True
                 except BaseException as e:
                     if verbose:
-                        sys.stderr.write('Warning: Unable to load {}: '.format(
-                            filename) + str(e) + '\n')
+                        sys.stderr.write(f"Warning: Unable to load {filename}:"
+                                         f" {str(e)}\n")
                     continue
 
-        if loaded or name in default.configs:
-            if not loaded:
-                if verbose:
-                    sys.stderr.write(
-                        'Loading default config for {}...\n'.format(name))
-                self.parser.read_string(default.configs[name],
-                                        'default_' + name)
-                loaded = True
-                loaded_from_default = True
-
-            if not self.parser.has_section('global'):
-                raise AttributeError(
-                    ("default config '{}' has no '{}' section").format(
-                        name, 'global'))
-
-            try:
-                self.parser.get('global', 'config_name')
-            except BaseException:
-                raise AttributeError(
-                    ("default config '{}' has no '{}' key").format(
-                        name, 'config_name'))
-
-            resection = re.compile(r'^([^.]*)(\..*)?')
-            for section in self.parser.sections():
-
-                match = resection.match(section)
-                if not match:
-                    raise RuntimeError(
-                        ("unable to match '{}' section name").format(section))
-
-                if not section == 'global':
-                    if match.group(2) and len(match.group(2)) == 0:
-                        setattr(self, section, config(section))
-                    else:
-                        try:
-                            subconfig = object.__getattribute__(
-                                self, match.group(1))
-                        except BaseException:
-                            setattr(self,
-                                    match.group(1), config(match.group(1)))
-                            subconfig = object.__getattribute__(
-                                self, match.group(1))
-
-                        try:
-                            subconfig.parser.add_section(
-                                'global' + match.group(2))
-                        except BaseException:
-                            pass
-
-                for option in self.parser.options(section):
-                    value = self.parser.get(section, option)
-                    if section == 'global':
-                        if self.parser.has_section(option):
-                            raise AttributeError(
-                                ("default config '{}' " +
-                                 "has global '{}' which " +
-                                 "overrides '{}' section").format(
-                                     name, option, option))
-                        setattr(self, option, value)
-                    else:
-                        if match.group(2) and len(match.group(2)) > 0:
-                            subconfig = object.__getattribute__(
-                                self, match.group(1))
-                            subconfig.parser.set('global' + match.group(2),
-                                                 option, value)
-                        else:
-                            subconfig = object.__getattribute__(self, section)
-                            setattr(subconfig, option, value)
+        if not loaded and name in default.configs:
+            if verbose:
+                sys.stderr.write(f"Loading default config for {name}...\n")
+            self.read_string(default.configs[name], 'default_' + name)
+            loaded = True
+            loaded_from_default = True
 
         if not loaded and verbose:
-            sys.stderr.write("Creating a new config for {}...\n".format(name))
+            sys.stderr.write(f"Creating a new config for {name}...\n")
 
-        if not self.parser.has_section('global'):
-            self.parser.add_section('global')
+        if not self.has_section("global"):
+            self.add_section("global")
 
-        try:
-            object.__getattribute__(self, 'config_name')
-        except BaseException:
-            self.config_name = 'global'
+        if "config_name" not in self["global"]:
+            self["config_name"] = 'global'
 
-        if loaded_from_default:
-            object.__setattr__(self, '_config_changed', True)
+        self._config_changed = loaded_from_default
+        self._initialised = True
+
+    def __getattr__(self, name: str) -> SectionProxyWrapper:
+        if not self._initialised:
+            return
+        # The global section exposes it's options directly instead of going
+        # though a section
+        if name in self["global"]:
+            return self["global"][name]
+        elif name in self:
+            return self[name]
         else:
-            object.__setattr__(self, '_config_changed', False)
+            return configparser.ConfigParser.__getattr__(self, name)
 
-    def save(self, path):
+    # Using the parent class' original getitem method but downcast the
+    # SectionProxy to our wrapper
+    def __getitem__(self, name: str) -> object:
+        s = configparser.ConfigParser.__getitem__(self, name)
+        object.__setattr__(s, "__class__", SectionProxyWrapper)
+        return s
+
+    def __setattr__(self, name: str, value: object):
+        # If we are done initializing our class, a set should be adding to the
+        # underlying parser instead of defining new attributes
+        if self._initialised and name not in self.__dir__():
+            # The options from the global section are exposed directly without
+            # the section name indirection
+            if name in self["global"]:
+                self["global"][name] = value
+            else:
+                self[name] = value
+        else:
+            object.__setattr__(self, name, value)
+
+    def no_docs(self) -> Iterator[str]:
+        "Return an iterator of over the sections, without the *.doc and the DEFAULT section"
+        return filter(lambda s: not s.endswith(".doc") and s != "DEFAULT", configparser.ConfigParser.__iter__(self))
+
+    def help(self, args: list[str] = [], level=0, indent=4, middle=40) -> str:
+        "Returns the doc string for name with the specified indentation"
+        if len(args) == 0:
+            msg = ""
+            for s in self.no_docs():
+                msg += self[s].help(None, level, indent, middle) + "\n"
+            return msg[:-1]  # Remove the last line feed
+        else:
+            if args[0] in self["global"]:
+                section = "global"
+                option = args[0]
+            else:
+                section = args[0]
+                option = args[1] if len(args) == 2 else None
+            return self[section].help(option, level, indent, middle)
+
+    def save(self, path: str):
+        "Write the config to disk"
         if self._config_changed:
             filename = os.path.join(path, self.config_name + ".ini")
             with open(filename, "w") as cfile:
                 self.write(cfile)
 
-    def __getattribute__(self, name):
-        config_get = config_getattribute
-        return config_get(self, name)
-
-    def __setattr__(self, name, value):
-        config_set = config_setattr
-        return config_set(self, name, value)
+# Alias to stay backwards compatible
+config = ConfigParser

--- a/src/fuddly/framework/plumbing.py
+++ b/src/fuddly/framework/plumbing.py
@@ -54,7 +54,7 @@ from pprint import pprint
 from fuddly.libs.importer import fuddly_importer_hook
 fuddly_importer_hook.setup()
 
-from fuddly.framework.config import config, config_dot_proxy, update_config
+from fuddly.framework.config import config, update_config, SectionProxyWrapper
 from fuddly.framework.cosmetics import aligned_stdout
 from fuddly.framework.database import FeedbackGate
 from fuddly.framework.data import Data, DataProcess
@@ -668,8 +668,8 @@ class FmkPlumbing(object):
         self.cleanup_all_dmakers(reset_existing_seed)
         # Warning: fuzz delay is not set to 0 by default in order to have a time frame
         # where SIGINT is accepted from user
-        delay = self.config.misc.fuzz.delay if self.prj.default_sending_delay is None else self.prj.default_sending_delay
-        burst = self.config.misc.fuzz.burst if self.prj.default_burst_value is None else self.prj.default_burst_value
+        delay = self.config.misc["fuzz.delay"] if self.prj.default_sending_delay is None else self.prj.default_sending_delay
+        burst = self.config.misc["fuzz.burst"] if self.prj.default_burst_value is None else self.prj.default_burst_value
         self.set_delay_between_two_actions(delay)
         self.set_sending_burst_counter(burst)
 
@@ -1311,12 +1311,13 @@ class FmkPlumbing(object):
         # Targets
         try:
             targets = module.targets
-            targets.insert(0, EmptyTarget(verbose=self.config.targets.empty_tg.verbose))
+            # the field has a . in it, so we use the dict syntax to access the options
+            targets.insert(0, EmptyTarget(verbose=self.config.targets["empty_tg.verbose"]))
         except AttributeError:
-            tg = EmptyTarget(verbose=self.config.targets.empty_tg.verbose)
+            tg = EmptyTarget(verbose=self.config.targets["empty_tg.verbose"])
             tg.set_project(prj)
             targets = [tg]
-        
+
         new_targets = []
         for obj in targets:
             if isinstance(obj, (tuple, list)):
@@ -5286,69 +5287,39 @@ class FmkShell(cmd.Cmd):
         return False
 
     def complete_config(self, text, line, bgidx, endix, target=None):
-        init = False
-        if target is None:
-            init = True
-
+        # Removing text from line, making completion inside the line work™
+        line = line[:bgidx]
         args = line.split()
-        if args[-1] == text:
-            args.pop()
-        if init:
-            if len(args) == 1:
+        comp = []
+
+        if len(args) > 1:
+            target = self.available_configs[args[1]]
+
+        match len(args):
+            case 1:
                 comp = [k for k in self.available_configs.keys()]
                 if text != "":
                     comp = [i for i in comp if i.startswith(text)]
-                return comp
-
-            try:
+            case 2:
+                comp = list(target["global"]) + list(target.no_docs())
                 if text != "":
-                    return self.complete_config(
-                        text,
-                        " ".join(["config"] + args[2:] + [text]),
-                        0,
-                        0,
-                        self.available_configs[args[1]],
-                    )
-                else:
-                    return self.complete_config(
-                        "",
-                        " ".join(["config"] + args[2:]),
-                        0,
-                        0,
-                        self.available_configs[args[1]],
-                    )
-            except KeyError:
-                pass
+                    comp = [i for i in comp if i.startswith(text)]
+                comp = [
+                    i.replace(".", " ")
+                    for i in comp
+                    if (i != "config_name" and i != "global")
+                ]
+            case 3:
+                comp = [x.replace(".", " ") for x in target[args[2]]]
+            # Residual completion of "sub-options"
+            case 4:
+                comp = [x for x in target[args[2]] if "." in x]
+                comp = [re.sub(r'.*\.', '', x) for x in comp]
 
-            return []
-
-        if len(args) == 1 and isinstance(target, config):
-            comp = target.parser.options("global") + target.parser.sections()
-            if text != "":
-                comp = [i for i in comp if i.startswith(text)]
-            comp = [
-                i.replace(".", " ")
-                for i in comp
-                if (i[-4:] != ".doc" and i != "config_name" and i != "global")
-            ]
-            return comp
-        if len(args) > 1 and args[1] == "shell":
-            return self.complete_config(
-                text, " ".join(args[1:] + [text]), 0, 0, self.config
-            )
-        if len(args) > 1 and target.parser.has_section(args[1]):
-            return self.complete_config(
-                    text,
-                    " ".join(args[1:] + [text]),
-                    0,
-                    0,
-                    getattr(target, args[1]))
-        comp = target.parser.options("global")
-        comp = [i for i in comp if i.startswith(args[-1] + ".")]
-        comp = [i[len(args[-1]) + 1 :] for i in comp
-                if (i[-4:] != ".doc" and i != "config_name" and i != "global")]
         if text != "":
             comp = [i for i in comp if i.startswith(text)]
+        # Adding a space makes completion nicer
+        comp = [x + " " for x in comp]
         return comp
 
     def do_config(self, line, target=None):
@@ -5357,99 +5328,98 @@ class FmkShell(cmd.Cmd):
         Usage:
          - config
                List all configuration options available.
-         - config [name [subname...]]
-               Get value associated with <name>.
-         - config [name [subname...]] value
-               Set value associated with <name>.
+         - config [name [section [option] | option]]
+               Get the documentation for the while <section> or <option>.
+         - config [name [section [option] | option]] value
+               Set value associated with <option> from <section> to <value>.
         """
         self.__error = True
 
-        level = self.config.config.indent.level
-        indent = self.config.config.indent.width
+        level = self.config.config["indent.level"]
+        indent = self.config.config["indent.width"]
         middle = self.config.config.middle
 
         args = line.split()
-        if target is None:
-            if len(args) == 0:
-                self.print("Available configurations:")
-                for target in self.available_configs:
-                    self.print(" - {}".format(target))
-                self.print('\n\t > Type "config <name>" to display documentation.')
-                self.__error = False
-                return False
-            else:
-                try:
-                    target = self.available_configs[args[0]]
-                    self._tmp_do_config_initial_target = target
-                    self.__error = False
-                    return self.do_config(" ".join(args[1:]), target)
-                except KeyError as e:
-                    self.print('Unknown config "{}": '.format(args[0]) + str(e))
-                return False
-
         if len(args) == 0:
-            self.print(target.help(None, level, indent, middle))
-            self.__error = False
-            return False
-        elif len(args) == 1:
-            self.print(target.help(args[0], level, indent, middle))
+            self.print("Available configurations:")
+            for target in self.available_configs:
+                self.print(f" - {target}")
+            self.print("\n\t > Usage: config [name [section [option [value]]]]")
             self.__error = False
             return False
 
-        section = args[0]
         try:
-            attr = getattr(target, section)
-        except:
-            self.__error_msg = "'{}' is not a valid config key".format(section)
+            target = self.available_configs[args[0]]
+        except KeyError:
+            self.__error = False
+            self.print(f'Unknown config "{args[0]}"\n')
+            self.do_config("")
+            self.__error = False
             return False
 
-        if isinstance(attr, config):
-            self.__error = False
-            return self.do_config(" ".join(args[1:]), attr)
-
-        if len(args) == 2:
-            if isinstance(attr, config_dot_proxy):
+        # Remove config type from args
+        args = args[1:]
+        match len(args):
+            # Get docs for a whole config file
+            case 0:
+                try:
+                    self.print(target.help([], level, indent, middle))
+                except KeyError as e:
+                    # Should never happen since a test was done when fetching the target
+                    self.print(f'Error getting docs for config "{target.name}": ' + str(e))
+                    return False
                 self.__error = False
-                key = ".".join(args)
-                self.print(target.help(key, level, indent, middle))
+                return False
+
+            # Get doc for a section of a config file
+            # Get the docs for a specific option in a section of a config file
+            case 1 | 2:
+                try:
+                    self.print(target.help(args, level, indent, middle))
+                except KeyError:
+                    if len(args) == 1:
+                        self.print(f'Unknown section "{args[0]}" in config "{target.name}"')
+                    else:
+                        self.print(f'Unknown option "{args[1]}" in section "{args[0]}" in config "{target.name}"')
+                    return False
                 self.__error = False
                 return False
 
-            try:
-                setattr(target, args[0], args[1])
-            except AttributeError as e:
-                self.__error_msg = "config: " + str(e)
+            # Set value or get a "sub-option"
+            case 3 | 4:
+                section = args[0]
+                option = args[1]
+                value = args[2]
+
+                if option not in target[section]:
+                    option = option + "." + value
+                    if len(args) == 4:
+                        value = args[3]
+                    else:
+                        new_line = " ".join(line.split(" ")[:-2] + [option])
+                        return self.do_config(new_line)
+
+                try:
+                    _ = target[section][option]
+                except KeyError:
+                    self.__error_msg = f"'{option}' is not a valid config key"
+                    return False
+
+                try:
+                    target[section][option] = value
+                except Exception as e:
+                    self.__error_msg = "config: " + str(e)
+                    return False
+
+                self.print(target.help(args[:-1], level, indent, middle))
+                self.__error = False
                 return False
-            else:
-                object.__setattr__(self._tmp_do_config_initial_target,
-                                   '_config_changed', True)
 
-            self.print(target.help(args[0], level, indent, middle))
-            self.__error = False
-            return False
+            case _:
+                self.do_config("")
+                self.__error = True
+                self.__error_msg = "Error: to many arguments"
 
-        if isinstance(attr, config_dot_proxy):
-            key = ".".join(args[:-1])
-            try:
-                attr = getattr(target, key)
-            except:
-                self.__error_msg = "'{}' is not a valid config key".format(key)
-                return False
-
-            try:
-                setattr(target, key, args[-1])
-            except AttributeError as e:
-                self.__error_msg = "config: " + str(e)
-                return False
-            else:
-                object.__setattr__(self._tmp_do_config_initial_target,
-                                   '_config_changed', True)
-
-            self.print(target.help(key, level, indent, middle))
-            self.__error = False
-            return False
-
-        self.__error_msg = "'{}' do not have subkeys".format(args[0])
         return False
 
     def do_exec_dm_tests(self, line):


### PR DESCRIPTION
Both the old and new config file parser are based on configparser.
The new one tries to make better use of it though, but not doing any
parsing itself.

The new parser exposes sections of the ini file, and the options inside
through a dict - like configparser does. It also make them all available
as attributes of the class, but without mangling the whole attribute
access mechanism.

To not add any ini parsing logic in the new configuration "parser", if
an option in the config file contains a dot (.), it will not be possible
to use the dot-notation to access said option. The nominal way of
accessing on of though will be the dict notation (object[option]), but
the getattr function will also be able to provide access to the attribute.

This has no effect on the cli interface where the config command still
uses a space separated notation for "sub-options"

I also added in some small changes that don't need their own PR.